### PR TITLE
Timezone sorting

### DIFF
--- a/timezones/zones.py
+++ b/timezones/zones.py
@@ -10,4 +10,8 @@ PRETTY_TIMEZONE_CHOICES = []
 
 for tz in pytz.common_timezones:
     now = datetime.now(pytz.timezone(tz))
-    PRETTY_TIMEZONE_CHOICES.append((tz, "(GMT%s) %s" % (now.strftime("%z"), tz)))
+    ofs = now.strftime("%z")
+    PRETTY_TIMEZONE_CHOICES.append((int(ofs), tz, "(GMT%s) %s" % (ofs, tz)))
+PRETTY_TIMEZONE_CHOICES.sort()
+for i in xrange(len(PRETTY_TIMEZONE_CHOICES)):
+    PRETTY_TIMEZONE_CHOICES[i] = PRETTY_TIMEZONE_CHOICES[i][1:]


### PR DESCRIPTION
Hi,

I added a simple patch to change the way timezones are sorted by default, in a way that I think is more user friendly.  With this change, we sort by (GMT offset, name) rather than just by (name).  Since the names tend to be hard to guess - my personal timezone is "America/Vancouver" even though I'm in Canada? - this makes it easier to find things in the list.

Have fun,

Avery
