### PR TITLE
Scoping issue in timezones/fields.py/prep_localized_datetime()

### DIFF
--- a/timezones/fields.py
+++ b/timezones/fields.py
@@ -122,6 +122,9 @@ def prep_localized_datetime(sender, **kwargs):
                 return getattr(instance, dt_field_name)
 
             def set_dtz_field(instance, dt):
+                if dt is None: # Allow None here (db will catch later for null=False)
+                    setattr(instance, dt_field_name, None)
+                    return
                 if dt.tzinfo is None:
                     dt = default_tz.localize(dt)
                 time_zone = field.timezone

--- a/timezones/fields.py
+++ b/timezones/fields.py
@@ -110,47 +110,55 @@ class LocalizedDateTimeField(models.DateTimeField):
 def prep_localized_datetime(sender, **kwargs):
     for field in sender._meta.fields:
         if not isinstance(field, LocalizedDateTimeField) or field.timezone is None:
+            field = None
             continue
-        dt_field_name = "_datetimezone_%s" % field.attname
-        def get_dtz_field(instance):
-            return getattr(instance, dt_field_name)
-        def set_dtz_field(instance, dt):
-            if dt.tzinfo is None:
-                dt = default_tz.localize(dt)
-            time_zone = field.timezone
-            if isinstance(field.timezone, basestring):
-                tz_name = instance._default_manager.filter(
-                    pk=model_instance._get_pk_val()
-                ).values_list(field.timezone)[0][0]
-                try:
-                    time_zone = pytz.timezone(tz_name)
-                except:
-                    time_zone = default_tz
-                if time_zone is None:
-                    # lookup failed
-                    time_zone = default_tz
-                    #raise pytz.UnknownTimeZoneError(
-                    #    "Time zone %r from relation %r was not found"
-                    #    % (tz_name, field.timezone)
-                    #)
-            elif callable(time_zone):
-                tz_name = time_zone()
-                if isinstance(tz_name, basestring):
+
+        # Beware python scoping and for loops (for loops don't introduce new scope)
+        # http://stackoverflow.com/questions/233673/lexical-closures-in-python
+        def gen_getset_dtz_field(field):
+            dt_field_name = "_datetimezone_%s" % field.attname
+
+            def get_dtz_field(instance):
+                return getattr(instance, dt_field_name)
+
+            def set_dtz_field(instance, dt):
+                if dt.tzinfo is None:
+                    dt = default_tz.localize(dt)
+                time_zone = field.timezone
+                if isinstance(field.timezone, basestring):
+                    tz_name = instance._default_manager.filter(
+                        pk=model_instance._get_pk_val()
+                        ).values_list(field.timezone)[0][0]
                     try:
                         time_zone = pytz.timezone(tz_name)
                     except:
                         time_zone = default_tz
-                else:
-                    time_zone = tz_name
-                if time_zone is None:
-                    # lookup failed
-                    time_zone = default_tz
-                    #raise pytz.UnknownTimeZoneError(
-                    #    "Time zone %r from callable %r was not found"
-                    #    % (tz_name, field.timezone)
-                    #)
-            setattr(instance, dt_field_name, dt.astimezone(time_zone))
-        setattr(sender, field.attname, property(get_dtz_field, set_dtz_field))
+                    if time_zone is None:
+                        # lookup failed
+                        time_zone = default_tz
+                        #raise pytz.UnknownTimeZoneError(
+                        #    "Time zone %r from relation %r was not found"
+                        #    % (tz_name, field.timezone)
+                        #)
+                elif callable(time_zone):
+                    tz_name = time_zone()
+                    if isinstance(tz_name, basestring):
+                        try:
+                            time_zone = pytz.timezone(tz_name)
+                        except:
+                            time_zone = default_tz
+                    else:
+                        time_zone = tz_name
+                    if time_zone is None:
+                        # lookup failed
+                        time_zone = default_tz
+                        #raise pytz.UnknownTimeZoneError(
+                        #    "Time zone %r from callable %r was not found"
+                        #    % (tz_name, field.timezone)
+                        #)
+                setattr(instance, dt_field_name, dt.astimezone(time_zone))
+            return (get_dtz_field, set_dtz_field)
+        setattr(sender, field.attname, property(*gen_getset_dtz_field(field)))
 
 ## RED_FLAG: need to add a check at manage.py validation time that
 ##           time_zone value is a valid query keyword (if it is one)


### PR DESCRIPTION
I think I filed this before, but it may have got lost when github totally reworked their pull request subsystem. Anyway, it looks to me like the issue is still present in your latest code at time of writing. 

You've got a scoping issue in prep_localized_datetime, just the [way python scoping works](http://stackoverflow.com/questions/233673/lexical-closures-in-python).   Without a fix, means you potentially get weird behaviour, particularly if you have multiple LocalizedDateTimeFields on the one model.  Anyway, attached is one possible suggestion to fix the issue.

N.B. I'm leaving django-land very shortly (end of contract), found this going through some old tickets prior to leaving, so  I personally may not be contactable regarding this issue after this thursday (31st March 2011) (bound to be someone at ichec.ie available, just not dgoldenichec...)
