### PR TITLE
Trying to fix deprecation warnings in Django 1.3 by adding "prepared" arg

### DIFF
--- a/timezones/fields.py
+++ b/timezones/fields.py
@@ -47,7 +47,7 @@ class TimeZoneField(models.CharField):
             return smart_unicode(value)
         return value
     
-    def get_db_prep_save(self, value, connection=None):
+    def get_db_prep_save(self, value, connection=None, prepared=None):
         """
         Prepares the given value for insertion into the database.
         """
@@ -83,7 +83,7 @@ class LocalizedDateTimeField(models.DateTimeField):
         defaults.update(kwargs)
         return super(LocalizedDateTimeField, self).formfield(**defaults)
     
-    def get_db_prep_save(self, value, connection=None):
+    def get_db_prep_save(self, value, connection=None, prepared=None):
         """
         Returns field's value prepared for saving into a database.
         """
@@ -93,7 +93,7 @@ class LocalizedDateTimeField(models.DateTimeField):
                 value = default_tz.localize(value)
             else:
                 value = value.astimezone(default_tz)
-        return super(LocalizedDateTimeField, self).get_db_prep_save(value, connection=connection)
+        return super(LocalizedDateTimeField, self).get_db_prep_save(value, connection=connection, prepared=prepared)
     
     def get_db_prep_lookup(self, lookup_type, value, connection=None, prepared=None):
         """


### PR DESCRIPTION
Trying to fix deprecation warnings in Django 1.3 by adding "prepared" argument to all get_db_prep_\* methods
Note: I amended 3 method signatures to take a 'prepared=' argument, which defaults to None. Two of the methods _use_ this method (in that it gets proxied to the super-method call), but for TimeZoneField::get_db_prep_save, the value of this param has no effect (I made no changes to actually use the parameter)

Thanks for the plugin, it's a huge help!
