### PR TITLE
A fix to remove timezone information from dates before inserting in the DB.

### DIFF
--- a/timezones/fields.py
+++ b/timezones/fields.py
@@ -93,6 +93,15 @@ class LocalizedDateTimeField(models.DateTimeField):
                 value = default_tz.localize(value)
             else:
                 value = value.astimezone(default_tz)
+        
+        # Make sure the DB can handle timezone-aware dates (hint: MySQL cannot)
+        if connection and getattr(connection, "ops") and getattr(connection.ops, "value_to_db_datetime"):
+            try:
+                connection.ops.value_to_db_datetime(value)
+            except ValueError:
+                # DB doesn't support timezones, so strip it off
+                value = value.replace(tzinfo=None)
+        
         return super(LocalizedDateTimeField, self).get_db_prep_save(value, connection=connection)
     
     def get_db_prep_lookup(self, lookup_type, value, connection=None, prepared=None):
@@ -104,14 +113,6 @@ class LocalizedDateTimeField(models.DateTimeField):
             value = default_tz.localize(value)
         else:
             value = value.astimezone(default_tz)
-        
-        # Make sure the DB can handle timezone-aware dates (hint: MySQL cannot)
-        if connection and getattr(connection, "ops") and getattr(connection.ops, "value_to_db_datetime"):
-            try:
-                connection.ops.value_to_db_datetime(value)
-            except ValueError:
-                # DB doesn't support timezones, so strip it off
-                value = value.replace(tzinfo=None)
         
         return super(LocalizedDateTimeField, self).get_db_prep_lookup(lookup_type, value, connection=connection, prepared=prepared)
 


### PR DESCRIPTION
A fix to remove timezone information from dates before inserting in the DB.

Some DBs do not support timezones on dates (notably, MySQL). We therefore have to remove the timezone information before storing the value. This is not too bad as we convert to the default timezone in `get_db_prep_save()`, and add the default timezone information back in `get_db_prep_lookup()`.

I have tried to code this in a way that will be both backwards compatible (no `connection` parameter in Django < 1.3) and not hard-wired to MySQL specifically.

Of course, if the user changes the default timezone while there is data in the database, it will cause the dates in the database to skew. This is not ideal, but there is not much we can do about this apart from either forcing all dates to be stored in UTC, or putting a suitably large warning somewhere in the docs.

For my part, I wouldn't not mind forcing to UTC, but I am in the UK, so the impact of that for me is probably going to be less.
