### PR TITLE
Add south introspection for TimeZoneField

### DIFF
--- a/timezones/fields.py
+++ b/timezones/fields.py
@@ -155,3 +155,16 @@ def prep_localized_datetime(sender, **kwargs):
 ## RED_FLAG: need to add a check at manage.py validation time that
 ##           time_zone value is a valid query keyword (if it is one)
 signals.class_prepared.connect(prep_localized_datetime)
+
+
+# Add south introspection for TimeZoneField
+try:
+    from south.modelsinspector import add_introspection_rules
+except ImportError:
+    pass
+else:
+    add_introspection_rules(rules=[((TimeZoneField,), [], {
+        "max_length": ["max_length", {"default": MAX_TIMEZONE_LENGTH}],
+        "default": ["default", {"default": settings.TIME_ZONE}],
+        "choices": ["choices", {"default": zones.PRETTY_TIMEZONE_CHOICES}],
+    })], patterns=["^timezones\.fields\."])


### PR DESCRIPTION
This is another alternative style to pull request #13.

Another alternative in a more usual style for South introspection code (may be less appropriate for this project's style):

```
# Add south introspection for TimeZoneField
try:
    from south.modelsinspector import add_introspection_rules
except ImportError:
    pass
else:
    add_introspection_rules(rules=[(
        (TimeZoneField,),
        [],
        {
            "max_length": ["max_length", {"default": MAX_TIMEZONE_LENGTH}],
            "default": ["default", {"default": settings.TIME_ZONE}],
            "choices": ["choices", {"default": zones.PRETTY_TIMEZONE_CHOICES}],
        }
    )], patterns=["^timezones\.fields\."])
```

I think South introspection code always looks ugly, but some sort of introspection is necessary for South to work at all with `TimeZoneField`s.
